### PR TITLE
Use DockerDownload link in docker_dump module

### DIFF
--- a/pkg/links/docker/extract.go
+++ b/pkg/links/docker/extract.go
@@ -10,6 +10,7 @@ import (
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
 	"github.com/praetorian-inc/janus-framework/pkg/types"
+	"github.com/praetorian-inc/nebula/pkg/links/options"
 )
 
 // DockerExtractToFS extracts Docker image files to the filesystem
@@ -26,7 +27,7 @@ func NewDockerExtractToFS(configs ...cfg.Config) chain.Link {
 
 func (de *DockerExtractToFS) Params() []cfg.Param {
 	return []cfg.Param{
-		cfg.NewParam[string]("output", "output directory to extract files to").WithDefault("docker-extracted"),
+		options.OutputDir(),
 		cfg.NewParam[bool]("extract", "enable extraction to filesystem").WithDefault(true),
 	}
 }
@@ -159,10 +160,10 @@ func NewDockerImageLoader(configs ...cfg.Config) chain.Link {
 
 func (dl *DockerImageLoader) Params() []cfg.Param {
 	return []cfg.Param{
-		cfg.NewParam[string]("image", "Docker image name to load"),
-		cfg.NewParam[string]("file", "File containing list of Docker images"),
-		cfg.NewParam[string]("docker-user", "Docker registry username"),
-		cfg.NewParam[string]("docker-password", "Docker registry password"),
+		options.DockerImage(),
+		options.File(),
+		options.DockerUser(),
+		options.DockerPassword(),
 	}
 }
 

--- a/pkg/links/docker/save.go
+++ b/pkg/links/docker/save.go
@@ -11,6 +11,7 @@ import (
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
 	"github.com/praetorian-inc/janus-framework/pkg/types"
+	"github.com/praetorian-inc/nebula/pkg/links/options"
 )
 
 type DockerSave struct {
@@ -26,7 +27,7 @@ func NewDockerSave(configs ...cfg.Config) chain.Link {
 
 func (dsl *DockerSave) Params() []cfg.Param {
 	return []cfg.Param{
-		cfg.NewParam[string]("output", "output directory to save images to"),
+		options.OutputDir(),
 	}
 }
 

--- a/pkg/links/options/docker_options.go
+++ b/pkg/links/options/docker_options.go
@@ -36,10 +36,6 @@ func DockerImage() cfg.Param {
 		WithShortcode("i")
 }
 
-func DockerFile() cfg.Param {
-	return cfg.NewParam[string]("file", "File containing list of Docker images").
-		WithShortcode("f")
-}
 
 func DockerUser() cfg.Param {
 	return cfg.NewParam[string]("docker-user", "Docker registry username")

--- a/pkg/links/options/generic_options.go
+++ b/pkg/links/options/generic_options.go
@@ -153,3 +153,8 @@ func OutputDir() cfg.Param {
 		WithShortcode("o").
 		WithDefault("nebula-output")
 }
+
+func File() cfg.Param {
+	return cfg.NewParam[string]("file", "input file path").
+		WithShortcode("f")
+}

--- a/pkg/modules/saas/recon/docker_dump.go
+++ b/pkg/modules/saas/recon/docker_dump.go
@@ -3,6 +3,7 @@ package recon
 import (
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	janusDocker "github.com/praetorian-inc/janus-framework/pkg/links/docker"
 	"github.com/praetorian-inc/janus-framework/pkg/links/noseyparker"
 	"github.com/praetorian-inc/nebula/internal/registry"
 	"github.com/praetorian-inc/nebula/pkg/links/docker"
@@ -23,10 +24,8 @@ var DockerDump = chain.NewModule(
 ).WithLinks(
 	// Load Docker images from file or single image input
 	docker.NewDockerImageLoader,
-	// Pull the Docker images
-	docker.NewDockerPull,
-	// Save images to local tar files
-	docker.NewDockerSave,
+	// Download images to local tar files
+	janusDocker.NewDockerDownload,
 	// Extract to filesystem
 	docker.NewDockerExtractToFS,
 	// Convert to NoseyParker inputs and scan

--- a/pkg/modules/saas/recon/docker_dump.go
+++ b/pkg/modules/saas/recon/docker_dump.go
@@ -3,9 +3,9 @@ package recon
 import (
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
-	"github.com/praetorian-inc/nebula/pkg/links/docker"
 	"github.com/praetorian-inc/janus-framework/pkg/links/noseyparker"
 	"github.com/praetorian-inc/nebula/internal/registry"
+	"github.com/praetorian-inc/nebula/pkg/links/docker"
 	"github.com/praetorian-inc/nebula/pkg/links/options"
 	"github.com/praetorian-inc/nebula/pkg/outputters"
 )
@@ -16,7 +16,7 @@ var DockerDump = chain.NewModule(
 		"Extract the file contents of a Docker container and optionally scan for secrets using NoseyParker.",
 	).WithProperties(map[string]any{
 		"id":          "docker-dump",
-		"platform":    "universal", 
+		"platform":    "universal",
 		"opsec_level": "none",
 		"authors":     []string{"Praetorian"},
 	}),
@@ -31,7 +31,7 @@ var DockerDump = chain.NewModule(
 	docker.NewDockerExtractToFS,
 	// Convert to NoseyParker inputs and scan
 	docker.NewDockerExtractToNP,
-	chain.ConstructLinkWithConfigs(noseyparker.NewNoseyParkerScanner, 
+	chain.ConstructLinkWithConfigs(noseyparker.NewNoseyParkerScanner,
 		cfg.WithArg("continue_piping", true)),
 ).WithInputParam(
 	options.DockerImage(),
@@ -44,7 +44,6 @@ var DockerDump = chain.NewModule(
 ).WithParams(
 	cfg.NewParam[string]("module-name", "name of the module for dynamic file naming"),
 ).WithOutputters(
-	outputters.NewRuntimeJSONOutputter,
 	outputters.NewNPFindingsConsoleOutputter,
 ).WithAutoRun()
 

--- a/pkg/modules/saas/recon/docker_dump.go
+++ b/pkg/modules/saas/recon/docker_dump.go
@@ -36,7 +36,6 @@ var DockerDump = chain.NewModule(
 ).WithInputParam(
 	options.DockerImage(),
 ).WithConfigs(
-	cfg.WithArg("file", ""),
 	cfg.WithArg("docker-user", ""),
 	cfg.WithArg("docker-password", ""),
 	cfg.WithArg("extract", "true"),

--- a/pkg/outputters/runtime_json.go
+++ b/pkg/outputters/runtime_json.go
@@ -57,7 +57,7 @@ func (j *RuntimeJSONOutputter) Initialize() error {
 	}
 
 	// Get default output file (can be overridden at runtime)
-	outfile, err := cfg.As[string](j.Arg("file"))
+	outfile, err := cfg.As[string](j.Arg("outfile"))
 	if err != nil {
 		outfile = defaultOutfile // Fallback default
 	}
@@ -319,7 +319,7 @@ func (j *RuntimeJSONOutputter) Params() []cfg.Param {
 	// Note: Platform parameters (profile, subscription, project) are passed from modules
 	// and accessed via j.Arg() but not declared here to avoid conflicts
 	return []cfg.Param{
-		cfg.NewParam[string]("file", "the default file to write the JSON to (can be changed at runtime)").WithDefault(defaultOutfile),
+		cfg.NewParam[string]("outfile", "the default file to write the JSON to (can be changed at runtime)").WithDefault(defaultOutfile),
 		cfg.NewParam[int]("indent", "the number of spaces to use for the JSON indentation").WithDefault(0),
 		cfg.NewParam[string]("module-name", "the name of the module for dynamic file naming"),
 		options.OutputDir(),


### PR DESCRIPTION
Changes the `docker_dump` module to use janus-framework's DockerDownload module instead off DockerPull/Save so the Docker daemon isn't a dependency.

Currently marking as a draft as this PR depends on #113, https://github.com/praetorian-inc/janus-framework/pull/4, and https://github.com/praetorian-inc/janus-framework/pull/5.

Here's a snippet of it working (trimming off some output for readability):
<img width="2208" height="1484" alt="image" src="https://github.com/user-attachments/assets/9e16d43d-aa5f-4ad6-a0d4-7e329a544b8c" />