### PR TITLE
Support specifying registry URLs without auth and document docker-dump module in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Nebula uses standard cloud provider authentication:
 - **AWS**: Environment variables, credentials file (~/.aws/credentials), IAM roles
 - **Azure**: Environment variables, Azure CLI, managed identity
 - **GCP**: Service account keys, application default credentials
+- **Docker**: Registry credentials via --docker-user and --docker-password flags
 
 ## Basic Usage
 
@@ -65,6 +66,9 @@ nebula azure recon public-resources -s subscription-id
 
 # Get GCP project information
 nebula gcp recon projects-list
+
+# Analyze Docker container for secrets
+nebula saas recon docker-dump -i nginx:latest
 ```
 
 ## Common Commands
@@ -97,6 +101,12 @@ nebula azure recon public-resources -s all
 nebula azure recon devops-secrets --organization org-name
 ```
 
+**SaaS Reconnaissance:**
+```bash
+# Docker container analysis and secret scanning
+nebula saas recon docker-dump -i image-name
+```
+
 **Analysis Modules:**
 ```bash
 # AWS key analysis
@@ -126,6 +136,7 @@ nebula aws analyze ip-lookup -i 1.2.3.4
 -r, --regions string  AWS regions ('all' or comma-separated)
 -s, --subscription    Azure subscription ID
 -t, --resource-type   Cloud resource type filter
+-i, --image string    Docker image name for SaaS modules
 ```
 
 ## MCP Server

--- a/pkg/links/docker/extract.go
+++ b/pkg/links/docker/extract.go
@@ -269,14 +269,13 @@ func (dl *DockerImageLoader) createImageContext(imageName string) types.DockerIm
 	if username != "" && password != "" {
 		imageContext.AuthConfig.Username = username
 		imageContext.AuthConfig.Password = password
-		
-		// Extract server address from image name
-		if strings.Contains(imageName, "/") {
-			parts := strings.SplitN(imageName, "/", 2)
-			if strings.Contains(parts[0], ".") {
-				imageContext.AuthConfig.ServerAddress = "https://" + parts[0]
-			}
-		}
+	}
+
+	// Extract server address from image name
+	parts := strings.SplitN(imageName, "/", 2)
+	if strings.Contains(parts[0], ".") {
+		imageContext.AuthConfig.ServerAddress = "https://" + parts[0]
+		imageContext.Image = parts[1]
 	}
 
 	return imageContext

--- a/pkg/links/options/docker_options.go
+++ b/pkg/links/options/docker_options.go
@@ -32,10 +32,11 @@ var DockerExtractOpt = types.Option{
 
 // Janus framework parameters
 func DockerImage() cfg.Param {
-	return cfg.NewParam[string]("image", "Docker image name to process").
+	return cfg.NewParam[string]("image",
+		"Docker image name to process. To download an image from a custom registry, prepend the\n"+
+			"image name with the registry URL. Example: ghcr.io/oj/gobuster").
 		WithShortcode("i")
 }
-
 
 func DockerUser() cfg.Param {
 	return cfg.NewParam[string]("docker-user", "Docker registry username")


### PR DESCRIPTION
Some registries, like `ghcr.io` and `mcr.microsoft.com`, allow anonymous access (or no need to auth at all) in the same way that DockerHub does. Therefore, this PR allows users to specify a registry URL in the image name without needing to supply a user/pass.

I also improved the description for the `--image` flag to show users how to specify a custom registry URL. But let me know if there is a better way to document that (e.g. in a user guide instead).

Last, the `docker-dump` module documentation was added to the Readme.