### PR TITLE
Adding quiet global flag

### DIFF
--- a/cmd/generator.go
+++ b/cmd/generator.go
@@ -217,26 +217,12 @@ func runModule(cmd *cobra.Command, module chain.Module, platform string) error {
 	})
 
 	message.Section("Running module %s", module.Metadata().Name)
-	
+
 	module.Run(configs...)
 
-	if platform == "aws" {
+	if platform == "aws" && !quietFlag {
 		helpers.ShowCacheStat()
 		helpers.PrintAllThrottlingCounts()
 	}
 	return module.Error()
-}
-
-func getFirstKey(m interface{}) string {
-	switch v := m.(type) {
-	case map[string]map[string][]string:
-		for k := range v {
-			return k
-		}
-	case map[string][]string:
-		for k := range v {
-			return k
-		}
-	}
-	return ""
 }

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	quiet     bool
+	quiet     bool = true
 	noColor   bool
 	silent    bool
 	mutex     sync.RWMutex


### PR DESCRIPTION
- Adds `quiet` global flag that suppresses message output and banner
- The `quiet` package variable is set to true, so programmatic use of modules has this by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --quiet flag to suppress non-essential CLI output across commands.
  - Color setting is applied consistently at startup for all subsequent messages.

- Behavior Changes
  - Startup banner and other messages now respect quiet and color settings and appear after configuration is applied.
  - Platform-specific post-run metrics are shown only when running on AWS and not in quiet mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->