### PR TITLE
bug fix in find-secrets

### DIFF
--- a/pkg/links/aws/cloudcontrol/cloud_control_list.go
+++ b/pkg/links/aws/cloudcontrol/cloud_control_list.go
@@ -79,15 +79,15 @@ func (a *AWSCloudControl) initializeClients() error {
 	return nil
 }
 
-func (a *AWSCloudControl) Process(resourceType string) error {
+func (a *AWSCloudControl) Process(resourceType model.CloudResourceType) error {
 	for _, region := range a.Regions {
-		if a.isGlobalService(resourceType, region) {
+		if a.isGlobalService(resourceType.String(), region) {
 			slog.Debug("Skipping global service", "type", resourceType, "region", region)
 			continue
 		}
 
 		a.wg.Add(1)
-		go a.listResourcesInRegion(resourceType, region)
+		go a.listResourcesInRegion(resourceType.String(), region)
 	}
 
 	a.wg.Wait()


### PR DESCRIPTION
fix error 

```
failed to process item in link \"*cloudcontrol.AWSCloudControl\": input \"model.CloudResourceType\" cannot be copied to output \"string\"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated the public API for resource processing to use a typed resource identifier instead of a plain string, improving type safety.
  - Internal logic adjusted to align with the new type without changing runtime behavior (regional processing and global-service handling remain the same).
  - Note: Integrations or scripts calling this API may require updates to accommodate the new parameter type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->