### PR TITLE
Fix Azure ARG scan --subscription all parameter

### DIFF
--- a/pkg/modules/azure/recon/arg_scan.go
+++ b/pkg/modules/azure/recon/arg_scan.go
@@ -20,6 +20,8 @@ var AzureARGScan = chain.NewModule(
 		"authors":     []string{"Praetorian"},
 	}),
 ).WithLinks(
+	// Generate subscription IDs (resolves "all" to actual subscription GUIDs)
+	azure.NewAzureSubscriptionGeneratorLink,
 	// Load ARG templates and create queries for each subscription
 	azure.NewARGTemplateLoaderLink,
 	// Execute the ARG queries and get resources


### PR DESCRIPTION
**Problem:**
The arg-scan module failed when using `--subscription all` with the error: "Subscription ids have to be valid GUIDs. Given: 'all'."

**Root Cause:**
1. Missing AzureSubscriptionGeneratorLink in the arg-scan module chain
2. ARGTemplateLoaderLink was ignoring piped subscription IDs from the chain

**Solution:**
1. Added azure.NewAzureSubscriptionGeneratorLink as first link in arg-scan chain
2. Modified ARGTemplateLoaderLink to prioritize string input (subscription ID) over command arguments

**Changes:**
- pkg/modules/azure/recon/arg_scan.go: Added subscription generator link
- pkg/links/azure/arg_template.go: Enhanced input handling logic

**Testing:**
✅ `--subscription all` now works correctly across all 6 accessible subscriptions
✅ `--subscription <guid>` continues to work (backward compatibility maintained)
✅ Successfully scanned 24 ARG templates across all subscriptions

<img width="1057" height="968" alt="image" src="https://github.com/user-attachments/assets/990e0e64-f85c-4a37-99d2-229ed8c41789" />
<img width="1194" height="703" alt="image" src="https://github.com/user-attachments/assets/5e3cbc9d-b06a-4020-ab98-c22ea7052454" />
