### PR TITLE
Re-adding ecr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/microsoftgraph/msgraph-sdk-go v1.53.0
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de
-	github.com/praetorian-inc/janus-framework v0.0.0-20250813151526-bc4f4c7279a7
+	github.com/praetorian-inc/janus-framework v0.0.0-20250909154949-2af6e196b0f2
 	github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157
 	github.com/praetorian-inc/tabularium v1.0.43
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/praetorian-inc/janus-framework v0.0.0-20250813151526-bc4f4c7279a7 h1:64xL/JYiBL9qHN9sFVEVBgJO1+T8u6DhssFnD4EuL1g=
 github.com/praetorian-inc/janus-framework v0.0.0-20250813151526-bc4f4c7279a7/go.mod h1:/K/qM9j43mrPe0VsYy5xUDNWT+pnk7ejBE4O7Lcg8RY=
+github.com/praetorian-inc/janus-framework v0.0.0-20250909154949-2af6e196b0f2 h1:+i5Vi/7smCbgbunY3yXJjXtICtUoUznfrXIqFiw5nc4=
+github.com/praetorian-inc/janus-framework v0.0.0-20250909154949-2af6e196b0f2/go.mod h1:/K/qM9j43mrPe0VsYy5xUDNWT+pnk7ejBE4O7Lcg8RY=
 github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157 h1:Hrov9II6t60IMF9wg8CqySnZi/2fdz/2DkAMcw48bkU=
 github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157/go.mod h1:sbwY5GVsqieoJXogpMMK+5GWZ15UgNnd9nRSkjBG8rQ=
 github.com/praetorian-inc/tabularium v1.0.43 h1:H6F7l+xh8OYljxVHDGGwPQ9Qt4C44JQKp+mFrXIbz0o=

--- a/pkg/links/aws/ecr/list-images.go
+++ b/pkg/links/aws/ecr/list-images.go
@@ -9,6 +9,7 @@ import (
 	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	"github.com/praetorian-inc/nebula/internal/message"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
 	"github.com/praetorian-inc/nebula/pkg/types"
 )
@@ -75,12 +76,13 @@ func (e *AWSECRListImages) Process(resource *types.EnrichedResourceDescription) 
 	}
 
 	var uri string
-	if latest.ImageTags != nil && len(latest.ImageTags) > 0 {
+	if len(latest.ImageTags) > 0 {
 		uri = fmt.Sprintf("%s/%s:%s", ecrRegistry, resource.Identifier, latest.ImageTags[0])
 	} else if latest.ImageDigest != nil {
 		uri = fmt.Sprintf("%s/%s@%s", ecrRegistry, resource.Identifier, *latest.ImageDigest)
 	}
 
+	message.Info("Processing image: %s", uri)
 	e.Send(uri)
 
 	return nil

--- a/pkg/links/aws/ecr/login-public.go
+++ b/pkg/links/aws/ecr/login-public.go
@@ -54,7 +54,7 @@ func (a *AWSECRLoginPublic) Process(repositoryURI string) error {
 		AuthConfig: registry.AuthConfig{
 			Username:      "AWS",
 			Password:      string(parsed),
-			ServerAddress: fmt.Sprintf("public.ecr.aws"),
+			ServerAddress: fmt.Sprintf("https://public.ecr.aws"),
 		},
 		Image: repositoryURI,
 	}

--- a/pkg/links/aws/ecr/login.go
+++ b/pkg/links/aws/ecr/login.go
@@ -53,7 +53,7 @@ func (a *AWSECRLogin) Process(registryURL string) error {
 		AuthConfig: registry.AuthConfig{
 			Username:      "AWS",
 			Password:      string(jwt),
-			ServerAddress: fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", account, region),
+			ServerAddress: fmt.Sprintf("https://%s.dkr.ecr.%s.amazonaws.com", account, region),
 		},
 		Image: registryURL,
 	}

--- a/pkg/links/aws/find_secrets.go
+++ b/pkg/links/aws/find_secrets.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	janusDocker "github.com/praetorian-inc/janus-framework/pkg/links/docker"
 	"github.com/praetorian-inc/janus-framework/pkg/links/noseyparker"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/cloudformation"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/ec2"
+	"github.com/praetorian-inc/nebula/pkg/links/aws/ecr"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/lambda"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/stepfunctions"
 	"github.com/praetorian-inc/nebula/pkg/types"
@@ -64,15 +66,14 @@ func (fs *AWSFindSecrets) ResourceMap() map[string]func() chain.Chain {
 		)
 	}
 
-	// resourceMap["AWS::ECR::Repository"] = func() chain.Chain {
-	// 	return chain.NewChain(
-	// 		ecr.NewAWSECRListImages(),
-	// 		ecr.NewAWSECRLogin(),
-	// 		docker.NewDockerPull(),
-	// 		docker.NewDockerSave(),
-	// 		noseyparker.NewConvertToNPInput(),
-	// 	)
-	// }
+	resourceMap["AWS::ECR::Repository"] = func() chain.Chain {
+		return chain.NewChain(
+			ecr.NewAWSECRListImages(),
+			ecr.NewAWSECRLogin(),
+			janusDocker.NewDockerDownload(),
+			noseyparker.NewConvertToNPInput(),
+		)
+	}
 
 	// resourceMap["AWS::ECR::PublicRepository"] = func() chain.Chain {
 	// 	return chain.NewChain(

--- a/pkg/modules/aws/recon/find_secrets.go
+++ b/pkg/modules/aws/recon/find_secrets.go
@@ -45,4 +45,4 @@ var AWSFindSecrets = chain.NewModule(
 	cfg.NewParam[string]("module-name", "name of the module for dynamic file naming"),
 ).WithConfigs(
 	cfg.WithArg("module-name", "find-secrets"),
-)
+).WithStrictness(chain.Lax)

--- a/pkg/outputters/np_findings_console.go
+++ b/pkg/outputters/np_findings_console.go
@@ -95,8 +95,16 @@ func (o *NPFindingsConsoleOutputter) outputFinding(finding types.NPFinding, inde
 		if finding.Provenance.ResourceID != "" {
 			provenanceDetails = append(provenanceDetails, fmt.Sprintf("Resource: %s", finding.Provenance.ResourceID))
 		}
+
 		if finding.Provenance.RepoPath != "" {
-			provenanceDetails = append(provenanceDetails, fmt.Sprintf("Repository: %s", finding.Provenance.RepoPath))
+			if finding.Provenance.FirstCommit != nil && finding.Provenance.FirstCommit.BlobPath != "" {
+				// For Docker layers: show layer and file within layer
+				provenanceDetails = append(provenanceDetails, fmt.Sprintf("Layer: %s", finding.Provenance.RepoPath))
+				provenanceDetails = append(provenanceDetails, fmt.Sprintf("File: %s", finding.Provenance.FirstCommit.BlobPath))
+			} else {
+				// For regular files: show file path
+				provenanceDetails = append(provenanceDetails, fmt.Sprintf("File: %s", finding.Provenance.RepoPath))
+			}
 		}
 
 		if len(provenanceDetails) > 0 {


### PR DESCRIPTION
Re-adding ECR and using new docker-less janus links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Improved findings display: Docker image results now show Layer and File details for clearer context.

* Bug Fixes
  * AWS ECR login updated to use HTTPS server addresses for public and private registries, improving authentication compatibility.

* Refactor
  * Streamlined AWS ECR image handling to simplify download workflow and speed up analysis.

* Chores
  * Adjusted AWS find-secrets module strictness to be more permissive during scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->