### PR TITLE
Fix: Empty S3 Bucket Policy Nil Dereference

### DIFF
--- a/pkg/links/aws/aws_resource_policy.go
+++ b/pkg/links/aws/aws_resource_policy.go
@@ -637,7 +637,7 @@ var ServicePolicyFuncMap = map[string]PolicyGetter{
 			slog.Debug("Failed to get bucket policy", "bucket", bucketName, "error", err)
 			// Continue since we need to evaluate bucket ACL
 		}
-		if resp.Policy != nil {
+		if resp != nil && resp.Policy != nil {
 			bucketPolicy, err = strToPolicy(*resp.Policy)
 			if err != nil {
 				slog.Debug("Error in converting string to policy, continuing to evaluate ACLs", "policy", *resp.Policy, "error", err)


### PR DESCRIPTION
fix nil pointer dereference crash when a nil s3 bucket policy is received

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when retrieving AWS S3 bucket policies, preventing rare crashes caused by unexpected empty responses.
  * Ensures policy data is processed only when available, avoiding intermittent errors in policy viewing or analysis flows.
* **Chores**
  * Minor defensive checks added to reduce nil-reference issues with external service responses, with no changes to user-facing behavior or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->