### PR TITLE
Use layer downloads in Docker dump module

### DIFF
--- a/docs/nebula_saas_recon_docker-dump.md
+++ b/docs/nebula_saas_recon_docker-dump.md
@@ -13,13 +13,12 @@ nebula saas recon docker-dump [flags]
       --datastore string         NoseyParker datastore file (default "datastore.np")
       --docker-password string   Docker registry password
       --docker-user string       Docker registry username
-      --extract                  enable extraction to filesystem (default true)
   -f, --file string              input file path
   -h, --help                     help for docker-dump
   -i, --image string             Docker image name to process. To download an image from a custom registry, prepend the
                                  image name with the registry URL. Example: ghcr.io/oj/gobuster
+      --max-file-size int        maximum file size to scan (in MB) (default 10)
       --module-name string       name of the module for dynamic file naming
-  -o, --output string            output directory (default "docker-images")
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,9 @@ require (
 	github.com/mark3labs/mcp-go v0.29.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/microsoftgraph/msgraph-sdk-go v1.53.0
+	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de
-	github.com/praetorian-inc/janus-framework v0.0.0-20250909154949-2af6e196b0f2
+	github.com/praetorian-inc/janus-framework v0.0.0-20250917152442-84f9f48ae382
 	github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157
 	github.com/praetorian-inc/tabularium v1.0.43
 	github.com/spf13/cobra v1.9.1
@@ -107,7 +108,6 @@ require (
 	github.com/microsoft/kiota-serialization-json-go v1.0.8 // indirect
 	github.com/microsoft/kiota-serialization-multipart-go v1.0.0 // indirect
 	github.com/microsoft/kiota-serialization-text-go v1.0.0 // indirect
-	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.1 // indirect
@@ -151,6 +151,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/sys v0.35.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
+	golang.org/x/text v0.28.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v1.53.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de
-	github.com/praetorian-inc/janus-framework v0.0.0-20250917152442-84f9f48ae382
+	github.com/praetorian-inc/janus-framework v0.0.0-20250918211123-5f90adc9184b
 	github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157
 	github.com/praetorian-inc/tabularium v1.0.43
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/praetorian-inc/janus-framework v0.0.0-20250917152442-84f9f48ae382 h1:psDYd2+b4YIMQxmJEG6XVIMY2+6aQN8RBijSb5EHFfo=
-github.com/praetorian-inc/janus-framework v0.0.0-20250917152442-84f9f48ae382/go.mod h1:/K/qM9j43mrPe0VsYy5xUDNWT+pnk7ejBE4O7Lcg8RY=
+github.com/praetorian-inc/janus-framework v0.0.0-20250918211123-5f90adc9184b h1:iTbo2sHfjQXbD19cVG3CC+7mh3jppmHsuiae5PMQIyY=
+github.com/praetorian-inc/janus-framework v0.0.0-20250918211123-5f90adc9184b/go.mod h1:/K/qM9j43mrPe0VsYy5xUDNWT+pnk7ejBE4O7Lcg8RY=
 github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157 h1:Hrov9II6t60IMF9wg8CqySnZi/2fdz/2DkAMcw48bkU=
 github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157/go.mod h1:sbwY5GVsqieoJXogpMMK+5GWZ15UgNnd9nRSkjBG8rQ=
 github.com/praetorian-inc/tabularium v1.0.43 h1:H6F7l+xh8OYljxVHDGGwPQ9Qt4C44JQKp+mFrXIbz0o=

--- a/go.sum
+++ b/go.sum
@@ -294,10 +294,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/praetorian-inc/janus-framework v0.0.0-20250813151526-bc4f4c7279a7 h1:64xL/JYiBL9qHN9sFVEVBgJO1+T8u6DhssFnD4EuL1g=
-github.com/praetorian-inc/janus-framework v0.0.0-20250813151526-bc4f4c7279a7/go.mod h1:/K/qM9j43mrPe0VsYy5xUDNWT+pnk7ejBE4O7Lcg8RY=
-github.com/praetorian-inc/janus-framework v0.0.0-20250909154949-2af6e196b0f2 h1:+i5Vi/7smCbgbunY3yXJjXtICtUoUznfrXIqFiw5nc4=
-github.com/praetorian-inc/janus-framework v0.0.0-20250909154949-2af6e196b0f2/go.mod h1:/K/qM9j43mrPe0VsYy5xUDNWT+pnk7ejBE4O7Lcg8RY=
+github.com/praetorian-inc/janus-framework v0.0.0-20250917152442-84f9f48ae382 h1:psDYd2+b4YIMQxmJEG6XVIMY2+6aQN8RBijSb5EHFfo=
+github.com/praetorian-inc/janus-framework v0.0.0-20250917152442-84f9f48ae382/go.mod h1:/K/qM9j43mrPe0VsYy5xUDNWT+pnk7ejBE4O7Lcg8RY=
 github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157 h1:Hrov9II6t60IMF9wg8CqySnZi/2fdz/2DkAMcw48bkU=
 github.com/praetorian-inc/konstellation v0.0.0-20250609145306-636c2e50b157/go.mod h1:sbwY5GVsqieoJXogpMMK+5GWZ15UgNnd9nRSkjBG8rQ=
 github.com/praetorian-inc/tabularium v1.0.43 h1:H6F7l+xh8OYljxVHDGGwPQ9Qt4C44JQKp+mFrXIbz0o=

--- a/pkg/links/aws/ecr/login-public.go
+++ b/pkg/links/aws/ecr/login-public.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
-	jtypes "github.com/praetorian-inc/janus-framework/pkg/types"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
 )
 
@@ -50,7 +50,7 @@ func (a *AWSECRLoginPublic) Process(repositoryURI string) error {
 		return nil
 	}
 
-	image := jtypes.DockerImage{
+	image := dockerTypes.DockerImage{
 		AuthConfig: registry.AuthConfig{
 			Username:      "AWS",
 			Password:      string(parsed),

--- a/pkg/links/aws/ecr/login.go
+++ b/pkg/links/aws/ecr/login.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
-	jtypes "github.com/praetorian-inc/janus-framework/pkg/types"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
 	"github.com/praetorian-inc/nebula/internal/helpers"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
 )
@@ -49,7 +49,7 @@ func (a *AWSECRLogin) Process(registryURL string) error {
 		return err
 	}
 
-	ic := jtypes.DockerImage{
+	ic := dockerTypes.DockerImage{
 		AuthConfig: registry.AuthConfig{
 			Username:      "AWS",
 			Password:      string(jwt),

--- a/pkg/links/docker/extract.go
+++ b/pkg/links/docker/extract.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
-	"github.com/praetorian-inc/janus-framework/pkg/types"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
 	"github.com/praetorian-inc/nebula/pkg/links/options"
 )
 
@@ -48,7 +48,7 @@ func (de *DockerExtractToFS) Initialize() error {
 	return nil
 }
 
-func (de *DockerExtractToFS) Process(imageContext types.DockerImage) error {
+func (de *DockerExtractToFS) Process(imageContext dockerTypes.DockerImage) error {
 	extract, err := cfg.As[bool](de.Arg("extract"))
 	if err != nil || !extract {
 		// Pass through without extraction
@@ -167,7 +167,7 @@ func NewDockerExtractToNP(configs ...cfg.Config) chain.Link {
 	return de
 }
 
-func (de *DockerExtractToNP) Process(imageContext types.DockerImage) error {
+func (de *DockerExtractToNP) Process(imageContext dockerTypes.DockerImage) error {
 	if imageContext.LocalPath == "" {
 		return fmt.Errorf("no local path available for image %s", imageContext.Image)
 	}
@@ -257,8 +257,8 @@ func (dl *DockerImageLoader) processFileInput(fileName string) error {
 	return nil
 }
 
-func (dl *DockerImageLoader) createImageContext(imageName string) types.DockerImage {
-	imageContext := types.DockerImage{
+func (dl *DockerImageLoader) createImageContext(imageName string) dockerTypes.DockerImage {
+	imageContext := dockerTypes.DockerImage{
 		Image: imageName,
 	}
 

--- a/pkg/links/docker/extract.go
+++ b/pkg/links/docker/extract.go
@@ -258,11 +258,6 @@ func (dl *DockerImageLoader) processFileInput(fileName string) error {
 }
 
 func (dl *DockerImageLoader) createImageContext(imageName string) dockerTypes.DockerImage {
-	if !strings.Contains(imageName, ":") {
-		// Explicitly specify the default tag to provide more context for what image is being used
-		imageName = fmt.Sprintf("%s:latest", imageName)
-	}
-
 	imageContext := dockerTypes.DockerImage{
 		Image: imageName,
 	}
@@ -278,7 +273,7 @@ func (dl *DockerImageLoader) createImageContext(imageName string) dockerTypes.Do
 
 	// Extract server address from image name
 	parts := strings.SplitN(imageName, "/", 2)
-	if strings.Contains(parts[0], ".") {
+	if len(parts) == 2 && strings.Contains(parts[0], ".") {
 		imageContext.AuthConfig.ServerAddress = "https://" + parts[0]
 		imageContext.Image = parts[1]
 	}

--- a/pkg/links/docker/extract.go
+++ b/pkg/links/docker/extract.go
@@ -258,6 +258,11 @@ func (dl *DockerImageLoader) processFileInput(fileName string) error {
 }
 
 func (dl *DockerImageLoader) createImageContext(imageName string) dockerTypes.DockerImage {
+	if !strings.Contains(imageName, ":") {
+		// Explicitly specify the default tag to provide more context for what image is being used
+		imageName = fmt.Sprintf("%s:latest", imageName)
+	}
+
 	imageContext := dockerTypes.DockerImage{
 		Image: imageName,
 	}

--- a/pkg/links/docker/extract_test.go
+++ b/pkg/links/docker/extract_test.go
@@ -124,7 +124,7 @@ func TestDockerImageLoader_createImageContext(t *testing.T) {
 			expected: dockerTypes.DockerImage{
 				Image:      "backend/api",
 				AuthConfig: registry.AuthConfig{
-					ServerAddress: "https://mycompany.azurecr.io",
+					ServerAddress: "https://company.azurecr.io",
 				},
 			},
 		},

--- a/pkg/links/docker/extract_test.go
+++ b/pkg/links/docker/extract_test.go
@@ -1,0 +1,160 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/registry"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
+)
+
+func TestDockerImageLoader_createImageContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		imageName string
+		expected  dockerTypes.DockerImage
+	}{
+		{
+			name:      "simple image no tag",
+			imageName: "nginx",
+			expected: dockerTypes.DockerImage{
+				Image: "nginx",
+			},
+		},
+		{
+			name:      "simple image with tag",
+			imageName: "nginx:1.20",
+			expected: dockerTypes.DockerImage{
+				Image: "nginx:1.20",
+			},
+		},
+		{
+			name:      "dockerhub org image no tag",
+			imageName: "library/nginx",
+			expected: dockerTypes.DockerImage{
+				Image: "library/nginx",
+			},
+		},
+		{
+			name:      "dockerhub org image with tag",
+			imageName: "library/nginx:alpine",
+			expected: dockerTypes.DockerImage{
+				Image: "library/nginx:alpine",
+			},
+		},
+		{
+			name:      "private registry domain no tag",
+			imageName: "registry.company.com/myapp",
+			expected: dockerTypes.DockerImage{
+				Image:      "myapp",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://registry.company.com",
+				},
+			},
+		},
+		{
+			name:      "private registry with org and tag",
+			imageName: "registry.company.com/backend/api:v2.1.0",
+			expected: dockerTypes.DockerImage{
+				Image:      "backend/api:v2.1.0",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://registry.company.com",
+				},
+			},
+		},
+		{
+			name:      "with digest",
+			imageName: "nginx@sha256:abc123def456789012345678901234567890123456789012345678901234567890",
+			expected: dockerTypes.DockerImage{
+				Image: "nginx@sha256:abc123def456789012345678901234567890123456789012345678901234567890",
+			},
+		},
+		{
+			name:      "registry with digest",
+			imageName: "registry.company.com/nginx@sha256:abc123def456789012345678901234567890123456789012345678901234567890",
+			expected: dockerTypes.DockerImage{
+				Image:      "nginx@sha256:abc123def456789012345678901234567890123456789012345678901234567890",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://registry.company.com",
+				},
+			},
+		},
+		{
+			name:      "ECR private registry",
+			imageName: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-web-app",
+			expected: dockerTypes.DockerImage{
+				Image:      "my-web-app",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://123456789012.dkr.ecr.us-east-1.amazonaws.com",
+				},
+			},
+		},
+		{
+			name:      "ECR private registry with tag",
+			imageName: "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-web-app:production",
+			expected: dockerTypes.DockerImage{
+				Image:      "my-web-app:production",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://123456789012.dkr.ecr.us-east-1.amazonaws.com",
+				},
+			},
+		},
+		{
+			name:      "ECR public registry",
+			imageName: "public.ecr.aws/nginx/nginx-unprivileged",
+			expected: dockerTypes.DockerImage{
+				Image:      "nginx/nginx-unprivileged",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://public.ecr.aws",
+				},
+			},
+		},
+		{
+			name:      "Google Container Registry",
+			imageName: "gcr.io/my-project/web-service",
+			expected: dockerTypes.DockerImage{
+				Image:      "my-project/web-service",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://gcr.io",
+				},
+			},
+		},
+		{
+			name:      "Azure Container Registry",
+			imageName: "company.azurecr.io/backend/api",
+			expected: dockerTypes.DockerImage{
+				Image:      "backend/api",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://mycompany.azurecr.io",
+				},
+			},
+		},
+		{
+			name:      "Quay registry",
+			imageName: "quay.io/prometheus/prometheus:v2.30.0",
+			expected: dockerTypes.DockerImage{
+				Image:      "prometheus/prometheus:v2.30.0",
+				AuthConfig: registry.AuthConfig{
+					ServerAddress: "https://quay.io",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dl := NewDockerImageLoader().(*DockerImageLoader)
+
+			result := dl.createImageContext(tt.imageName)
+
+			if result.Image != tt.expected.Image {
+				t.Errorf("createImageContext(%q).Image = %q, want %q", 
+					tt.imageName, result.Image, tt.expected.Image)
+			}
+
+			if result.AuthConfig.ServerAddress != tt.expected.AuthConfig.ServerAddress {
+				t.Errorf("createImageContext(%q).AuthConfig.ServerAddress = %q, want %q", 
+					tt.imageName, result.AuthConfig.ServerAddress, tt.expected.AuthConfig.ServerAddress)
+			}
+		})
+	}
+}

--- a/pkg/links/docker/helpers.go
+++ b/pkg/links/docker/helpers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
-	"github.com/praetorian-inc/janus-framework/pkg/types"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
 )
 
 func DockerExtractDomain(rawURL string) (string, error) {
@@ -53,11 +53,11 @@ func unauthenciated(ctx context.Context, retry bool, opts ...client.Opt) (*clien
 	return dockerClient, nil
 }
 
-func NewAuthenticatedClient(ctx context.Context, imageContext types.DockerImage, opts ...client.Opt) (*client.Client, error) {
+func NewAuthenticatedClient(ctx context.Context, imageContext dockerTypes.DockerImage, opts ...client.Opt) (*client.Client, error) {
 	return authenticate(ctx, imageContext, true, opts...)
 }
 
-func authenticate(ctx context.Context, imageContext types.DockerImage, retry bool, opts ...client.Opt) (*client.Client, error) {
+func authenticate(ctx context.Context, imageContext dockerTypes.DockerImage, retry bool, opts ...client.Opt) (*client.Client, error) {
 	dockerClient, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/links/docker/pull.go
+++ b/pkg/links/docker/pull.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
-	"github.com/praetorian-inc/janus-framework/pkg/types"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
 )
 
 type DockerPull struct {
@@ -26,7 +26,7 @@ func NewDockerPull(configs ...cfg.Config) chain.Link {
 	return dp
 }
 
-func (dp *DockerPull) Process(imageContext types.DockerImage) error {
+func (dp *DockerPull) Process(imageContext dockerTypes.DockerImage) error {
 	imageContext.Image = strings.TrimSpace(imageContext.Image)
 	if imageContext.Image == "" {
 		return nil
@@ -67,7 +67,7 @@ func (dp *DockerPull) Process(imageContext types.DockerImage) error {
 	return dp.Send(&imageContext)
 }
 
-func (dp *DockerPull) authenticate(imageContext types.DockerImage, pullOpts *image.PullOptions, opts ...client.Opt) (*client.Client, error) {
+func (dp *DockerPull) authenticate(imageContext dockerTypes.DockerImage, pullOpts *image.PullOptions, opts ...client.Opt) (*client.Client, error) {
 	dockerClient, err := NewAuthenticatedClient(dp.Context(), imageContext, opts...)
 
 	if err != nil {

--- a/pkg/links/docker/save.go
+++ b/pkg/links/docker/save.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
-	"github.com/praetorian-inc/janus-framework/pkg/types"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
 	"github.com/praetorian-inc/nebula/pkg/links/options"
 )
 
@@ -50,7 +50,7 @@ func (dsl *DockerSave) Initialize() error {
 	return nil
 }
 
-func (dsl *DockerSave) Process(imageContext types.DockerImage) error {
+func (dsl *DockerSave) Process(imageContext dockerTypes.DockerImage) error {
 	isPublicImage := strings.Contains(imageContext.AuthConfig.ServerAddress, "public.ecr.aws")
 
 	var dockerClient *client.Client

--- a/pkg/links/gcp/containers/artifactory.go
+++ b/pkg/links/gcp/containers/artifactory.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/praetorian-inc/janus-framework/pkg/chain"
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
-	jtypes "github.com/praetorian-inc/janus-framework/pkg/types"
+	dockerTypes "github.com/praetorian-inc/janus-framework/pkg/types/docker"
 	"github.com/praetorian-inc/nebula/pkg/links/gcp/base"
 	"github.com/praetorian-inc/nebula/pkg/links/options"
 	"github.com/praetorian-inc/nebula/pkg/utils"
@@ -261,7 +261,7 @@ func (g *GcpContainerImageSecretsLink) Process(input tab.GCPResource) error {
 	if err != nil {
 		return utils.HandleGcpError(err, "failed to get docker image for secrets extraction")
 	}
-	dockerImage := jtypes.DockerImage{
+	dockerImage := dockerTypes.DockerImage{
 		Image: image.Uri,
 		AuthConfig: registry.AuthConfig{
 			ServerAddress: g.extractRegistryURL(image.Uri),

--- a/pkg/modules/saas/recon/docker_dump.go
+++ b/pkg/modules/saas/recon/docker_dump.go
@@ -22,14 +22,10 @@ var DockerDump = chain.NewModule(
 		"authors":     []string{"Praetorian"},
 	}),
 ).WithLinks(
-	// Load Docker images from file or single image input
 	docker.NewDockerImageLoader,
-	// Download images to local tar files
-	janusDocker.NewDockerDownload,
-	// Extract to filesystem
-	docker.NewDockerExtractToFS,
-	// Convert to NoseyParker inputs and scan
-	docker.NewDockerExtractToNP,
+	janusDocker.NewDockerGetLayers,
+	janusDocker.NewDockerDownloadLayer,
+	janusDocker.NewDockerLayerToNP,
 	chain.ConstructLinkWithConfigs(noseyparker.NewNoseyParkerScanner,
 		cfg.WithArg("continue_piping", true)),
 ).WithInputParam(
@@ -40,8 +36,10 @@ var DockerDump = chain.NewModule(
 	cfg.WithArg("extract", "true"),
 	cfg.WithArg("noseyparker-scan", "true"),
 	cfg.WithArg("module-name", "docker-dump"),
+	cfg.WithArg("max-file-size", 10),
 ).WithParams(
 	cfg.NewParam[string]("module-name", "name of the module for dynamic file naming"),
+	cfg.NewParam[int]("max-file-size", "maximum file size to scan (in MB)").WithDefault(10),
 ).WithOutputters(
 	outputters.NewNPFindingsConsoleOutputter,
 ).WithAutoRun()


### PR DESCRIPTION
This PR changes the `docker_dump.go` module to use layer-by-layer downloads from https://github.com/praetorian-inc/janus-framework/pull/9. This significantly increases the memory efficiency of the module to allow it to scan large images in a fairly small memory footprint--even with a 15GB image, the runtime memory of Nebula never surpasses 3-4 GB.