### PR TITLE
Add detection of CloudFront distributions with non-existent S3 origins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
 	github.com/aws/aws-sdk-go v1.55.5
-	github.com/aws/aws-sdk-go-v2 v1.39.0
+	github.com/aws/aws-sdk-go-v2 v1.39.2
 	github.com/aws/aws-sdk-go-v2/config v1.29.6
 	github.com/aws/aws-sdk-go-v2/service/account v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11
@@ -73,6 +73,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.18.12 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.4.2 // indirect
@@ -139,8 +140,8 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/account v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.57.0
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.46.3
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.202.4
@@ -34,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoice v1.24.2
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.2
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.34.11
@@ -73,7 +75,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.18.12 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
-github.com/aws/aws-sdk-go-v2 v1.39.0 h1:xm5WV/2L4emMRmMjHFykqiA4M/ra0DJVSWUkDyBjbg4=
-github.com/aws/aws-sdk-go-v2 v1.39.0/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2 v1.39.2 h1:EJLg8IdbzgeD7xgvZ+I8M1e0fL0ptn/M47lianzth0I=
 github.com/aws/aws-sdk-go-v2 v1.39.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 h1:zAybnyUQXIZ5mok5Jqwlf58/TFE7uvd3IAsa1aF9cXs=
@@ -76,12 +74,8 @@ github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.18.12 h1:mwAIR3f
 github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.18.12/go.mod h1:9cWrNL8q7ApFmZzKhnb63ub4zrdMzOGQVn/kxvagfeE=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7 h1:Is2tPmieqGS2edBnmOJIbdvOA6Op+rRpaYR60iBAwXM=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7/go.mod h1:F1i5V5421EGci570yABvpIXgRIBPb5JM+lSkHF6Dq5w=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7 h1:UCxq0X9O3xrlENdKf1r9eRJoKz/b0AfGkpp3a7FPlhg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7/go.mod h1:rHRoJUNUASj5Z/0eqI4w32vKvC7atoWR0jC+IkmVH8k=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9 h1:se2vOWGD3dWQUtfn4wEjRQJb1HK1XsNIt825gskZ970=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9/go.mod h1:hijCGH2VfbZQxqCDN7bwz/4dzxV+hkyhjawAtdPWKZA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7 h1:Y6DTZUn7ZUC4th9FMBbo8LVE+1fyq3ofw+tRwkUd3PY=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7/go.mod h1:x3XE6vMnU9QvHN/Wrx2s44kwzV2o2g5x/siw4ZUJ9g8=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9 h1:6RBnKZLkJM4hQ+kN6E7yWFveOTg8NLPHAkqrs4ZPlTU=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9/go.mod h1:V9rQKRmK7AWuEsOMnHzKj8WyrIir1yUJbZxDuZLFvXI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 h1:Pg9URiobXy85kgFev3og2CuOZ8JZUBENF+dcgWBaYNk=
@@ -132,6 +126,8 @@ github.com/aws/aws-sdk-go-v2/service/organizations v1.38.3 h1:rAUHsUFmux71j/4wQ5
 github.com/aws/aws-sdk-go-v2/service/organizations v1.38.3/go.mod h1:iYC/SPpI4WveHr4ZzPFWTmXRODyJub5Aif75W7Ll+yM=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoice v1.24.2 h1:a0uy0ez4H9lxdvFuq/8D3AvVG45zPrUln4NStdE4rWY=
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoice v1.24.2/go.mod h1:1VFbsgdjRlvKbLBrNUliIRjpVSfhZ5jeRNS3Y4qDrww=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.58.4 h1:KycXrohD5OxAZ5h02YechO2gevvoHfAPAaJM5l8zqb0=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.58.4/go.mod h1:xNLZLn4SusktBQ5moqUOgiDKGz3a7vHwF4W0KD+WBPc=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.66.0 h1:xA6XhTF7PE89BCNHJbQi8VvPzcgMtmGC5dr8S8N7lHk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.66.0/go.mod h1:cB6oAuus7YXRZhWCc1wIwPywwZ1XwweNp2TVAEGYeB8=
 github.com/aws/aws-sdk-go-v2/service/serverlessapplicationrepository v1.24.2 h1:kZH4TxPNznySgGp9HaHNdWnpTnn8cFBNaBYu4ViN6PI=

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.39.0 h1:xm5WV/2L4emMRmMjHFykqiA4M/ra0DJVSWUkDyBjbg4=
 github.com/aws/aws-sdk-go-v2 v1.39.0/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
+github.com/aws/aws-sdk-go-v2 v1.39.2 h1:EJLg8IdbzgeD7xgvZ+I8M1e0fL0ptn/M47lianzth0I=
+github.com/aws/aws-sdk-go-v2 v1.39.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 h1:zAybnyUQXIZ5mok5Jqwlf58/TFE7uvd3IAsa1aF9cXs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10/go.mod h1:qqvMj6gHLR/EXWZw4ZbqlPbQUyenf4h82UQUlKc+l14=
 github.com/aws/aws-sdk-go-v2/config v1.29.6 h1:fqgqEKK5HaZVWLQoLiC9Q+xDlSp+1LYidp6ybGE2OGg=
@@ -76,8 +78,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7 h1:Is2tPmieqGS2edBnmOJIbdv
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.7/go.mod h1:F1i5V5421EGci570yABvpIXgRIBPb5JM+lSkHF6Dq5w=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7 h1:UCxq0X9O3xrlENdKf1r9eRJoKz/b0AfGkpp3a7FPlhg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.7/go.mod h1:rHRoJUNUASj5Z/0eqI4w32vKvC7atoWR0jC+IkmVH8k=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9 h1:se2vOWGD3dWQUtfn4wEjRQJb1HK1XsNIt825gskZ970=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9/go.mod h1:hijCGH2VfbZQxqCDN7bwz/4dzxV+hkyhjawAtdPWKZA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7 h1:Y6DTZUn7ZUC4th9FMBbo8LVE+1fyq3ofw+tRwkUd3PY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.7/go.mod h1:x3XE6vMnU9QvHN/Wrx2s44kwzV2o2g5x/siw4ZUJ9g8=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9 h1:6RBnKZLkJM4hQ+kN6E7yWFveOTg8NLPHAkqrs4ZPlTU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9/go.mod h1:V9rQKRmK7AWuEsOMnHzKj8WyrIir1yUJbZxDuZLFvXI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 h1:Pg9URiobXy85kgFev3og2CuOZ8JZUBENF+dcgWBaYNk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.21 h1:7edmS3VOBDhK00b/MwGtGglCm7hhwNYnjJs/PgFdMQE=
@@ -88,6 +94,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11 h1:vsDNkqiXTCeTaSt1qN
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.23.11/go.mod h1:aH+Z4h+QZfJ2iEP+EITPDP8nZI1eFUJu38V6c9Nq9uQ=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.57.0 h1:T4MRGuPFk/R8kHDNH8XKQCv5jnFuj60xs82eRZq+4Ls=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.57.0/go.mod h1:N9kHHkhOTqyLGAq+liCrRnmJ1OSLLvfHc0M/gu3qlwg=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4 h1:tVpbQcr1A0c+VTqtKEN9vfB0qer2SjfxX3LYojSGUq0=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.54.4/go.mod h1:dYwFVhUsRZt7COcGP23ei0lY8gX8ZSHrbyX49VB93MA=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.46.3 h1:psaBtnzfGXdAbQblMRMB66b5rQ4EfqRuNeD71DsAa2s=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.46.3/go.mod h1:FAKuqIR85M3yrw9AtlzCd0MLq6KZPllx17m+oCyr9j0=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.38.1 h1:HncrihDko4doTAsUWMiiRib3nD1I1JfB8DXOypr1yMc=

--- a/pkg/links/aws/cloudfront/cloudfront_distribution_enumerator.go
+++ b/pkg/links/aws/cloudfront/cloudfront_distribution_enumerator.go
@@ -1,0 +1,192 @@
+package cloudfront
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	"github.com/praetorian-inc/janus-framework/pkg/chain"
+	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	"github.com/praetorian-inc/nebula/internal/helpers"
+	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
+)
+
+// CloudFrontDistributionEnumerator enumerates all CloudFront distributions
+type CloudFrontDistributionEnumerator struct {
+	*base.AwsReconLink
+}
+
+// CloudFrontDistributionInfo contains information about a CloudFront distribution
+type CloudFrontDistributionInfo struct {
+	ID         string       `json:"id"`
+	DomainName string       `json:"domain_name"`
+	Aliases    []string     `json:"aliases,omitempty"`
+	Region     string       `json:"region"`
+	AccountID  string       `json:"account_id"`
+	Origins    []OriginInfo `json:"origins"`
+}
+
+// OriginInfo contains information about a CloudFront origin
+type OriginInfo struct {
+	ID         string `json:"id"`
+	DomainName string `json:"domain_name"`
+	OriginType string `json:"origin_type"` // "s3", "custom", etc.
+}
+
+// NewCloudFrontDistributionEnumerator creates a new CloudFront distribution enumerator
+func NewCloudFrontDistributionEnumerator(configs ...cfg.Config) chain.Link {
+	enumerator := &CloudFrontDistributionEnumerator{}
+	enumerator.AwsReconLink = base.NewAwsReconLink(enumerator, configs...)
+	return enumerator
+}
+
+// Process enumerates CloudFront distributions
+func (c *CloudFrontDistributionEnumerator) Process(resource any) error {
+	// CloudFront is a global service, always use us-east-1
+	region := "us-east-1"
+
+	config, err := c.GetConfigWithRuntimeArgs(region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS config: %w", err)
+	}
+
+	accountID, err := c.GetAccountID(config)
+	if err != nil {
+		slog.Warn("Failed to get account ID", "error", err)
+		accountID = "unknown"
+	}
+
+	client := cloudfront.NewFromConfig(config)
+
+	slog.Info("Enumerating CloudFront distributions")
+
+	paginator := cloudfront.NewListDistributionsPaginator(client, &cloudfront.ListDistributionsInput{})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(context.TODO())
+		if err != nil {
+			slog.Error("Failed to list distributions", "error", err)
+			return err
+		}
+
+		if page.DistributionList == nil || page.DistributionList.Items == nil {
+			slog.Debug("No CloudFront distributions found")
+			continue
+		}
+
+		for _, distSummary := range page.DistributionList.Items {
+			if distSummary.Id == nil {
+				continue
+			}
+
+			// Get detailed distribution config
+			distResult, err := client.GetDistribution(context.TODO(), &cloudfront.GetDistributionInput{
+				Id: distSummary.Id,
+			})
+			if err != nil {
+				slog.Error("Failed to get distribution details", "id", *distSummary.Id, "error", err)
+				continue
+			}
+
+			if distResult.Distribution == nil || distResult.Distribution.DistributionConfig == nil {
+				continue
+			}
+
+			dist := distResult.Distribution
+			config := dist.DistributionConfig
+
+			// Build distribution info
+			info := CloudFrontDistributionInfo{
+				ID:         *distSummary.Id,
+				DomainName: *distSummary.DomainName,
+				Region:     region,
+				AccountID:  accountID,
+			}
+
+			// Get aliases
+			if config.Aliases != nil && config.Aliases.Items != nil {
+				info.Aliases = config.Aliases.Items
+			}
+
+			// Get origins
+			if config.Origins != nil && config.Origins.Items != nil {
+				for _, origin := range config.Origins.Items {
+					if origin.DomainName == nil || origin.Id == nil {
+						continue
+					}
+
+					originInfo := OriginInfo{
+						ID:         *origin.Id,
+						DomainName: *origin.DomainName,
+					}
+
+					// Determine origin type
+					if origin.S3OriginConfig != nil {
+						originInfo.OriginType = "s3"
+					} else if origin.CustomOriginConfig != nil {
+						originInfo.OriginType = "custom"
+					} else {
+						// Check if domain looks like S3
+						domainName := *origin.DomainName
+						if isS3Domain(domainName) {
+							originInfo.OriginType = "s3"
+						} else {
+							originInfo.OriginType = "custom"
+						}
+					}
+
+					info.Origins = append(info.Origins, originInfo)
+				}
+			}
+
+			slog.Info("Found CloudFront distribution",
+				"id", info.ID,
+				"domain", info.DomainName,
+				"aliases", len(info.Aliases),
+				"origins", len(info.Origins))
+
+			// Send distribution info to next link
+			if err := c.Send(info); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetAccountID retrieves the AWS account ID
+func (c *CloudFrontDistributionEnumerator) GetAccountID(config aws.Config) (string, error) {
+	return helpers.GetAccountId(config)
+}
+
+// isS3Domain checks if a domain looks like an S3 domain
+func isS3Domain(domain string) bool {
+	// Check for various S3 domain patterns
+	patterns := []string{
+		".s3.amazonaws.com",
+		".s3-",
+		".s3.",
+	}
+
+	for _, pattern := range patterns {
+		if contains(domain, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// contains checks if a string contains a substring
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/links/aws/cloudfront/cloudfront_misconfiguration_detector.go
+++ b/pkg/links/aws/cloudfront/cloudfront_misconfiguration_detector.go
@@ -1,0 +1,321 @@
+package cloudfront
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cloudfronttypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/praetorian-inc/janus-framework/pkg/chain"
+	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
+	"github.com/praetorian-inc/nebula/pkg/types"
+)
+
+type CloudFrontMisconfigurationDetector struct {
+	*base.AwsReconLink
+	httpClient *http.Client
+}
+
+type SecurityFinding struct {
+	Type        string `json:"type"`
+	Severity    string `json:"severity"`
+	Domain      string `json:"domain,omitempty"`
+	Description string `json:"description"`
+	Evidence    string `json:"evidence,omitempty"`
+}
+
+func NewCloudFrontMisconfigurationDetector(configs ...cfg.Config) chain.Link {
+	detector := &CloudFrontMisconfigurationDetector{
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+	}
+	detector.AwsReconLink = base.NewAwsReconLink(detector, configs...)
+	return detector
+}
+
+func (c *CloudFrontMisconfigurationDetector) Process(resource *types.EnrichedResourceDescription) error {
+	if resource.TypeName != "AWS::CloudFront::Distribution" {
+		slog.Debug("Skipping non-CloudFront distribution", "resource", resource.TypeName)
+		return nil
+	}
+
+	// CloudFront is a global service, always use us-east-1
+	region := "us-east-1"
+	if resource.Region != "" {
+		region = resource.Region
+	}
+
+	config, err := c.GetConfigWithRuntimeArgs(region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS config for region %s: %w", region, err)
+	}
+
+	client := cloudfront.NewFromConfig(config)
+
+	distributionID := resource.Identifier
+	slog.Info("Analyzing CloudFront distribution for misconfigurations", "distribution_id", distributionID)
+
+	distribution, err := c.getDistributionConfig(client, distributionID)
+	if err != nil {
+		slog.Error("Failed to get distribution config", "distribution_id", distributionID, "error", err)
+		return nil
+	}
+
+	findings := c.detectMisconfigurations(distribution)
+
+	// Add findings to the resource properties
+	if len(findings) > 0 {
+		if resource.Properties == nil {
+			resource.Properties = make(map[string]any)
+		}
+
+		// Convert properties to map if it's not already
+		props, ok := resource.Properties.(map[string]any)
+		if !ok {
+			props = make(map[string]any)
+			resource.Properties = props
+		}
+
+		// Add findings to properties
+		props["SecurityFindings"] = findings
+		props["HasSecurityFindings"] = true
+		props["FindingsCount"] = len(findings)
+
+		// Log the findings
+		for _, finding := range findings {
+			slog.Info("CloudFront security finding detected",
+				"distribution_id", distributionID,
+				"type", finding.Type,
+				"severity", finding.Severity,
+				"domain", finding.Domain,
+				"description", finding.Description)
+		}
+	}
+
+	// Send the enriched resource with findings
+	return c.Send(resource)
+}
+
+func (c *CloudFrontMisconfigurationDetector) getDistributionConfig(client *cloudfront.Client, distributionID string) (*cloudfronttypes.Distribution, error) {
+	input := &cloudfront.GetDistributionInput{
+		Id: &distributionID,
+	}
+
+	result, err := client.GetDistribution(context.TODO(), input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get distribution: %w", err)
+	}
+
+	return result.Distribution, nil
+}
+
+func (c *CloudFrontMisconfigurationDetector) detectMisconfigurations(distribution *cloudfronttypes.Distribution) []SecurityFinding {
+	var findings []SecurityFinding
+
+	if distribution.DistributionConfig == nil {
+		return findings
+	}
+
+	config := distribution.DistributionConfig
+
+	findings = append(findings, c.checkDomainMisconfigurations(config)...)
+	findings = append(findings, c.checkSSLConfiguration(config)...)
+	findings = append(findings, c.checkOriginSecurity(config)...)
+	findings = append(findings, c.checkAccessControlConfiguration(config)...)
+	findings = append(findings, c.checkProtocolSecurity(config)...)
+
+	return findings
+}
+
+func (c *CloudFrontMisconfigurationDetector) checkDomainMisconfigurations(config *cloudfronttypes.DistributionConfig) []SecurityFinding {
+	var findings []SecurityFinding
+
+	if config.Aliases == nil || config.Aliases.Items == nil {
+		return findings
+	}
+
+	for _, alias := range config.Aliases.Items {
+		domain := alias
+
+		httpResp, httpErr := c.testHTTPEndpoint("http://" + domain)
+		_, httpsErr := c.testHTTPEndpoint("https://" + domain)
+
+		if httpErr != nil && strings.Contains(httpErr.Error(), "403") && strings.Contains(httpErr.Error(), "Bad request") {
+			if httpsErr != nil && (strings.Contains(httpsErr.Error(), "handshake") || strings.Contains(httpsErr.Error(), "certificate")) {
+				findings = append(findings, SecurityFinding{
+					Type:        "dangling_cname",
+					Severity:    "high",
+					Domain:      domain,
+					Description: fmt.Sprintf("Domain %s appears to have a dangling CNAME record pointing to CloudFront", domain),
+					Evidence:    fmt.Sprintf("HTTP: %v, HTTPS: %v", httpErr, httpsErr),
+				})
+			}
+		}
+
+		if httpResp != nil && httpResp.StatusCode == 403 {
+			body := make([]byte, 1024)
+			httpResp.Body.Read(body)
+			httpResp.Body.Close()
+			if strings.Contains(string(body), "Bad request") {
+				findings = append(findings, SecurityFinding{
+					Type:        "potential_takeover",
+					Severity:    "high",
+					Domain:      domain,
+					Description: fmt.Sprintf("Domain %s returns CloudFront 403 Bad Request error, indicating potential subdomain takeover vulnerability", domain),
+					Evidence:    "HTTP 403 response with 'Bad request' message from CloudFront",
+				})
+			}
+		}
+	}
+
+	return findings
+}
+
+func (c *CloudFrontMisconfigurationDetector) testHTTPEndpoint(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	return resp, err
+}
+
+func (c *CloudFrontMisconfigurationDetector) checkSSLConfiguration(config *cloudfronttypes.DistributionConfig) []SecurityFinding {
+	var findings []SecurityFinding
+
+	if config.ViewerCertificate == nil {
+		return findings
+	}
+
+	cert := config.ViewerCertificate
+
+	if cert.CloudFrontDefaultCertificate != nil && *cert.CloudFrontDefaultCertificate {
+		findings = append(findings, SecurityFinding{
+			Type:        "default_ssl_certificate",
+			Severity:    "medium",
+			Description: "Distribution is using CloudFront default SSL certificate instead of custom certificate",
+			Evidence:    "ViewerCertificate.CloudFrontDefaultCertificate is true",
+		})
+	}
+
+	if cert.MinimumProtocolVersion != "" {
+		protocol := string(cert.MinimumProtocolVersion)
+		if strings.Contains(protocol, "TLSv1_") || strings.Contains(protocol, "SSLv3") {
+			findings = append(findings, SecurityFinding{
+				Type:        "weak_ssl_protocol",
+				Severity:    "high",
+				Description: fmt.Sprintf("Distribution allows weak SSL/TLS protocol: %s", protocol),
+				Evidence:    fmt.Sprintf("MinimumProtocolVersion: %s", protocol),
+			})
+		}
+	}
+
+	return findings
+}
+
+func (c *CloudFrontMisconfigurationDetector) checkOriginSecurity(config *cloudfronttypes.DistributionConfig) []SecurityFinding {
+	var findings []SecurityFinding
+
+	if config.Origins == nil || config.Origins.Items == nil {
+		return findings
+	}
+
+	for _, origin := range config.Origins.Items {
+		if origin.CustomOriginConfig != nil {
+			customConfig := origin.CustomOriginConfig
+
+			if customConfig.OriginProtocolPolicy == cloudfronttypes.OriginProtocolPolicyHttpOnly {
+				findings = append(findings, SecurityFinding{
+					Type:        "insecure_origin_protocol",
+					Severity:    "medium",
+					Description: fmt.Sprintf("Origin %s uses HTTP-only protocol, data transmitted in plain text", *origin.DomainName),
+					Evidence:    "OriginProtocolPolicy is http-only",
+				})
+			}
+
+			if customConfig.OriginSslProtocols != nil && customConfig.OriginSslProtocols.Items != nil {
+				for _, protocol := range customConfig.OriginSslProtocols.Items {
+					if protocol == cloudfronttypes.SslProtocolTLSv1 || protocol == cloudfronttypes.SslProtocolSSLv3 {
+						findings = append(findings, SecurityFinding{
+							Type:        "weak_origin_ssl",
+							Severity:    "high",
+							Description: fmt.Sprintf("Origin %s allows weak SSL protocol: %s", *origin.DomainName, string(protocol)),
+							Evidence:    fmt.Sprintf("OriginSslProtocols contains %s", string(protocol)),
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return findings
+}
+
+func (c *CloudFrontMisconfigurationDetector) checkAccessControlConfiguration(config *cloudfronttypes.DistributionConfig) []SecurityFinding {
+	var findings []SecurityFinding
+
+	if config.Logging != nil && config.Logging.Enabled != nil && !*config.Logging.Enabled {
+		findings = append(findings, SecurityFinding{
+			Type:        "logging_disabled",
+			Severity:    "medium",
+			Description: "Access logging is disabled for CloudFront distribution",
+			Evidence:    "Logging.Enabled is false",
+		})
+	}
+
+	if config.WebACLId == nil || (config.WebACLId != nil && *config.WebACLId == "") {
+		findings = append(findings, SecurityFinding{
+			Type:        "no_waf_integration",
+			Severity:    "medium",
+			Description: "No AWS WAF integration configured for additional protection",
+			Evidence:    "WebACLId is empty",
+		})
+	}
+
+	return findings
+}
+
+func (c *CloudFrontMisconfigurationDetector) checkProtocolSecurity(config *cloudfronttypes.DistributionConfig) []SecurityFinding {
+	var findings []SecurityFinding
+
+	if config.DefaultCacheBehavior != nil {
+		behavior := config.DefaultCacheBehavior
+
+		if behavior.ViewerProtocolPolicy == cloudfronttypes.ViewerProtocolPolicyAllowAll {
+			findings = append(findings, SecurityFinding{
+				Type:        "insecure_viewer_protocol",
+				Severity:    "medium",
+				Description: "Distribution allows both HTTP and HTTPS traffic, potentially exposing sensitive data",
+				Evidence:    "ViewerProtocolPolicy is allow-all",
+			})
+		}
+	}
+
+	if config.CacheBehaviors != nil && config.CacheBehaviors.Items != nil {
+		for _, behavior := range config.CacheBehaviors.Items {
+			if behavior.ViewerProtocolPolicy == cloudfronttypes.ViewerProtocolPolicyAllowAll {
+				findings = append(findings, SecurityFinding{
+					Type:        "insecure_cache_behavior",
+					Severity:    "medium",
+					Description: fmt.Sprintf("Cache behavior for path %s allows HTTP traffic", *behavior.PathPattern),
+					Evidence:    "ViewerProtocolPolicy is allow-all for cache behavior",
+				})
+			}
+		}
+	}
+
+	return findings
+}

--- a/pkg/links/aws/cloudfront/cloudfront_s3_origin_checker.go
+++ b/pkg/links/aws/cloudfront/cloudfront_s3_origin_checker.go
@@ -1,0 +1,213 @@
+package cloudfront
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/praetorian-inc/janus-framework/pkg/chain"
+	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
+)
+
+// CloudFrontS3OriginChecker checks if S3 buckets referenced in CloudFront origins exist
+type CloudFrontS3OriginChecker struct {
+	*base.AwsReconLink
+}
+
+// VulnerableDistribution contains information about a vulnerable CloudFront distribution
+type VulnerableDistribution struct {
+	DistributionID     string   `json:"distribution_id"`
+	DistributionDomain string   `json:"distribution_domain"`
+	Aliases            []string `json:"aliases,omitempty"`
+	MissingBucket      string   `json:"missing_bucket"`
+	OriginDomain       string   `json:"origin_domain"`
+	OriginID           string   `json:"origin_id"`
+	AccountID          string   `json:"account_id"`
+	Region             string   `json:"region"`
+	Severity           string   `json:"severity"`
+	Risk               string   `json:"risk"`
+}
+
+// NewCloudFrontS3OriginChecker creates a new S3 origin checker
+func NewCloudFrontS3OriginChecker(configs ...cfg.Config) chain.Link {
+	checker := &CloudFrontS3OriginChecker{}
+	checker.AwsReconLink = base.NewAwsReconLink(checker, configs...)
+	return checker
+}
+
+// Process checks if S3 origins exist
+func (c *CloudFrontS3OriginChecker) Process(resource any) error {
+	distInfo, ok := resource.(CloudFrontDistributionInfo)
+	if !ok {
+		slog.Debug("Skipping non-CloudFront distribution info")
+		return nil
+	}
+
+	slog.Debug("Checking S3 origins for distribution", "id", distInfo.ID, "origins", len(distInfo.Origins))
+
+	// Check each S3 origin
+	for _, origin := range distInfo.Origins {
+		if origin.OriginType != "s3" {
+			continue
+		}
+
+		bucketName := extractBucketName(origin.DomainName)
+		if bucketName == "" {
+			slog.Warn("Could not extract bucket name from S3 origin",
+				"distribution_id", distInfo.ID,
+				"origin", origin.DomainName)
+			continue
+		}
+
+		slog.Debug("Checking S3 bucket existence",
+			"distribution_id", distInfo.ID,
+			"bucket", bucketName,
+			"origin", origin.DomainName)
+
+		exists, err := c.checkBucketExists(bucketName)
+		if err != nil {
+			slog.Warn("Error checking bucket existence",
+				"bucket", bucketName,
+				"error", err)
+			// Continue checking other buckets
+			continue
+		}
+
+		if !exists {
+			slog.Info("VULNERABLE: Found CloudFront distribution with non-existent S3 bucket",
+				"distribution_id", distInfo.ID,
+				"distribution_domain", distInfo.DomainName,
+				"missing_bucket", bucketName,
+				"origin_domain", origin.DomainName)
+
+			// Create vulnerability finding
+			vuln := VulnerableDistribution{
+				DistributionID:     distInfo.ID,
+				DistributionDomain: distInfo.DomainName,
+				Aliases:            distInfo.Aliases,
+				MissingBucket:      bucketName,
+				OriginDomain:       origin.DomainName,
+				OriginID:           origin.ID,
+				AccountID:          distInfo.AccountID,
+				Region:             distInfo.Region,
+				Severity:           "HIGH",
+				Risk: fmt.Sprintf("CloudFront distribution %s points to non-existent S3 bucket '%s'. "+
+					"An attacker could create this bucket to serve malicious content on your domain.",
+					distInfo.ID, bucketName),
+			}
+
+			// Send vulnerability to next link
+			if err := c.Send(vuln); err != nil {
+				return err
+			}
+		} else {
+			slog.Debug("S3 bucket exists",
+				"distribution_id", distInfo.ID,
+				"bucket", bucketName)
+		}
+	}
+
+	return nil
+}
+
+// checkBucketExists checks if an S3 bucket exists
+func (c *CloudFrontS3OriginChecker) checkBucketExists(bucketName string) (bool, error) {
+	// Try multiple regions as bucket could be in any region
+	regions := []string{"us-east-1", "us-west-2", "eu-west-1", "ap-northeast-1"}
+
+	for _, region := range regions {
+		config, err := c.GetConfigWithRuntimeArgs(region)
+		if err != nil {
+			continue
+		}
+
+		s3Client := s3.NewFromConfig(config)
+
+		// Use HeadBucket to check if bucket exists
+		_, err = s3Client.HeadBucket(context.TODO(), &s3.HeadBucketInput{
+			Bucket: &bucketName,
+		})
+
+		if err == nil {
+			// Bucket exists and we have access
+			return true, nil
+		}
+
+		// Check the error type
+		var noSuchBucket *s3types.NoSuchBucket
+		if errors.As(err, &noSuchBucket) {
+			// Bucket definitely does not exist
+			return false, nil
+		}
+
+		// Check for access denied - bucket exists but we can't access it
+		errStr := err.Error()
+		if strings.Contains(errStr, "AccessDenied") || strings.Contains(errStr, "Forbidden") {
+			// Bucket exists but we don't have access (not a takeover risk)
+			return true, nil
+		}
+
+		if strings.Contains(errStr, "PermanentRedirect") || strings.Contains(errStr, "301") {
+			// Bucket exists in a different region, try next region
+			continue
+		}
+
+		// Some other error, log and continue
+		slog.Debug("Unexpected error checking bucket",
+			"bucket", bucketName,
+			"error", err)
+		continue
+	}
+
+	// If we couldn't determine in any region, assume it doesn't exist (conservative approach)
+	return false, nil
+}
+
+// extractBucketName extracts the bucket name from an S3 domain
+func extractBucketName(originDomain string) string {
+	// Remove protocol if present
+	domain := strings.TrimPrefix(originDomain, "https://")
+	domain = strings.TrimPrefix(domain, "http://")
+
+	// Patterns for S3 origins:
+	// - bucket-name.s3.amazonaws.com
+	// - bucket-name.s3.region.amazonaws.com
+	// - bucket-name.s3-region.amazonaws.com
+	// - s3.amazonaws.com/bucket-name (path-style, older)
+
+	patterns := []string{
+		`^([^.]+)\.s3\.amazonaws\.com`,
+		`^([^.]+)\.s3\.([a-z0-9-]+)\.amazonaws\.com`,
+		`^([^.]+)\.s3-([a-z0-9-]+)\.amazonaws\.com`,
+		`^s3\.amazonaws\.com/([^/]+)`,
+		`^s3\.([a-z0-9-]+)\.amazonaws\.com/([^/]+)`,
+		`^s3-([a-z0-9-]+)\.amazonaws\.com/([^/]+)`,
+	}
+
+	for _, pattern := range patterns {
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(domain)
+		if len(matches) > 1 {
+			// Return the first captured group (bucket name)
+			return matches[1]
+		}
+		// For path-style URLs, bucket name might be in the last captured group
+		if len(matches) > 2 && matches[2] != "" && !strings.Contains(matches[2], "-") {
+			return matches[2]
+		}
+	}
+
+	// If no pattern matches, try simple heuristic
+	// Check if it looks like bucket.s3* pattern
+	if idx := strings.Index(domain, ".s3"); idx > 0 {
+		return domain[:idx]
+	}
+
+	return ""
+}

--- a/pkg/links/aws/cloudfront/route53_domain_finder.go
+++ b/pkg/links/aws/cloudfront/route53_domain_finder.go
@@ -1,0 +1,237 @@
+package cloudfront
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/route53"
+	"github.com/praetorian-inc/janus-framework/pkg/chain"
+	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
+)
+
+// Route53DomainFinder finds Route53 records pointing to vulnerable CloudFront distributions
+type Route53DomainFinder struct {
+	*base.AwsReconLink
+}
+
+// Route53Record contains information about a Route53 record
+type Route53Record struct {
+	ZoneID     string `json:"zone_id"`
+	ZoneName   string `json:"zone_name"`
+	RecordName string `json:"record_name"`
+	RecordType string `json:"record_type"`
+	Value      string `json:"value"`
+}
+
+// S3TakeoverFinding contains the complete vulnerability finding
+type S3TakeoverFinding struct {
+	DistributionID     string          `json:"distribution_id"`
+	DistributionDomain string          `json:"distribution_domain"`
+	Aliases            []string        `json:"aliases,omitempty"`
+	MissingBucket      string          `json:"missing_bucket"`
+	OriginDomain       string          `json:"origin_domain"`
+	OriginID           string          `json:"origin_id"`
+	AccountID          string          `json:"account_id"`
+	Region             string          `json:"region"`
+	Route53Records     []Route53Record `json:"route53_records,omitempty"`
+	AffectedDomains    []string        `json:"affected_domains"`
+	Severity           string          `json:"severity"`
+	Risk               string          `json:"risk"`
+	Remediation        string          `json:"remediation"`
+}
+
+// NewRoute53DomainFinder creates a new Route53 domain finder
+func NewRoute53DomainFinder(configs ...cfg.Config) chain.Link {
+	finder := &Route53DomainFinder{}
+	finder.AwsReconLink = base.NewAwsReconLink(finder, configs...)
+	return finder
+}
+
+// Process finds Route53 records pointing to vulnerable distributions
+func (r *Route53DomainFinder) Process(resource any) error {
+	vuln, ok := resource.(VulnerableDistribution)
+	if !ok {
+		// Not a vulnerable distribution, pass through
+		return r.Send(resource)
+	}
+
+	slog.Info("Searching Route53 for domains pointing to vulnerable CloudFront distribution",
+		"distribution_id", vuln.DistributionID,
+		"distribution_domain", vuln.DistributionDomain)
+
+	// Route53 is a global service, use us-east-1
+	config, err := r.GetConfigWithRuntimeArgs("us-east-1")
+	if err != nil {
+		return fmt.Errorf("failed to get AWS config: %w", err)
+	}
+
+	route53Client := route53.NewFromConfig(config)
+
+	// Find all Route53 records pointing to this distribution
+	records, err := r.findRoute53Records(route53Client, vuln.DistributionDomain, vuln.Aliases)
+	if err != nil {
+		slog.Warn("Error searching Route53 records", "error", err)
+		// Don't fail completely, still report the vulnerability
+		records = []Route53Record{}
+	}
+
+	// Build affected domains list
+	affectedDomains := []string{}
+	for _, record := range records {
+		affectedDomains = append(affectedDomains, record.RecordName)
+	}
+
+	// Add aliases as potentially affected domains
+	for _, alias := range vuln.Aliases {
+		if !containsString(affectedDomains, alias) {
+			affectedDomains = append(affectedDomains, alias)
+		}
+	}
+
+	// Create complete finding
+	finding := S3TakeoverFinding{
+		DistributionID:     vuln.DistributionID,
+		DistributionDomain: vuln.DistributionDomain,
+		Aliases:            vuln.Aliases,
+		MissingBucket:      vuln.MissingBucket,
+		OriginDomain:       vuln.OriginDomain,
+		OriginID:           vuln.OriginID,
+		AccountID:          vuln.AccountID,
+		Region:             vuln.Region,
+		Route53Records:     records,
+		AffectedDomains:    affectedDomains,
+		Severity:           "CRITICAL",
+		Risk: fmt.Sprintf("CloudFront distribution %s points to non-existent S3 bucket '%s'. "+
+			"An attacker could create this bucket to serve malicious content on %d domain(s): %s",
+			vuln.DistributionID, vuln.MissingBucket, len(affectedDomains), strings.Join(affectedDomains, ", ")),
+		Remediation: fmt.Sprintf("1. Delete the CloudFront distribution %s if no longer needed, OR\n"+
+			"2. Create the S3 bucket '%s' in your account to reclaim ownership, OR\n"+
+			"3. Update the distribution to point to a different origin",
+			vuln.DistributionID, vuln.MissingBucket),
+	}
+
+	if len(records) > 0 {
+		slog.Info("Found Route53 records pointing to vulnerable distribution",
+			"distribution_id", vuln.DistributionID,
+			"records", len(records),
+			"affected_domains", affectedDomains)
+	} else {
+		slog.Info("No Route53 records found (DNS may be managed externally)",
+			"distribution_id", vuln.DistributionID)
+	}
+
+	// Send complete finding
+	return r.Send(finding)
+}
+
+// findRoute53Records finds all Route53 records pointing to a CloudFront distribution
+func (r *Route53DomainFinder) findRoute53Records(client *route53.Client, cloudfrontDomain string, aliases []string) ([]Route53Record, error) {
+	var matchingRecords []Route53Record
+
+	// Normalize CloudFront domain
+	cloudfrontDomain = strings.TrimSuffix(cloudfrontDomain, ".")
+
+	// Get all hosted zones
+	zonesPaginator := route53.NewListHostedZonesPaginator(client, &route53.ListHostedZonesInput{})
+
+	for zonesPaginator.HasMorePages() {
+		zonesPage, err := zonesPaginator.NextPage(context.TODO())
+		if err != nil {
+			slog.Warn("Failed to list hosted zones", "error", err)
+			continue
+		}
+
+		for _, zone := range zonesPage.HostedZones {
+			if zone.Id == nil || zone.Name == nil {
+				continue
+			}
+
+			zoneID := strings.TrimPrefix(*zone.Id, "/hostedzone/")
+			zoneName := strings.TrimSuffix(*zone.Name, ".")
+
+			// Get all records in this zone
+			recordsPaginator := route53.NewListResourceRecordSetsPaginator(client, &route53.ListResourceRecordSetsInput{
+				HostedZoneId: &zoneID,
+			})
+
+			for recordsPaginator.HasMorePages() {
+				recordsPage, err := recordsPaginator.NextPage(context.TODO())
+				if err != nil {
+					slog.Debug("Failed to list records in zone", "zone", zoneName, "error", err)
+					continue
+				}
+
+				for _, record := range recordsPage.ResourceRecordSets {
+					if record.Name == nil {
+						continue
+					}
+
+					recordName := strings.TrimSuffix(*record.Name, ".")
+					recordType := string(record.Type)
+
+					// Check A and AAAA records with alias targets
+					if (recordType == "A" || recordType == "AAAA") && record.AliasTarget != nil {
+						if record.AliasTarget.DNSName != nil {
+							aliasTarget := strings.TrimSuffix(*record.AliasTarget.DNSName, ".")
+
+							// Check if this record points to our CloudFront distribution
+							if aliasTarget == cloudfrontDomain {
+								matchingRecords = append(matchingRecords, Route53Record{
+									ZoneID:     zoneID,
+									ZoneName:   zoneName,
+									RecordName: recordName,
+									RecordType: recordType,
+									Value:      aliasTarget,
+								})
+
+								slog.Debug("Found Route53 alias record pointing to CloudFront",
+									"record", recordName,
+									"type", recordType,
+									"target", aliasTarget)
+							}
+						}
+					}
+
+					// Check CNAME records
+					if recordType == "CNAME" && record.ResourceRecords != nil {
+						for _, rr := range record.ResourceRecords {
+							if rr.Value != nil {
+								cnameValue := strings.TrimSuffix(*rr.Value, ".")
+
+								// Check if CNAME points to CloudFront distribution or one of its aliases
+								if cnameValue == cloudfrontDomain || containsString(aliases, cnameValue) {
+									matchingRecords = append(matchingRecords, Route53Record{
+										ZoneID:     zoneID,
+										ZoneName:   zoneName,
+										RecordName: recordName,
+										RecordType: recordType,
+										Value:      cnameValue,
+									})
+
+									slog.Debug("Found Route53 CNAME record pointing to CloudFront",
+										"record", recordName,
+										"target", cnameValue)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return matchingRecords, nil
+}
+
+// containsString checks if a string slice contains a string
+func containsString(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/links/aws/public_resources.go
+++ b/pkg/links/aws/public_resources.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log/slog"
 	"sync"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/base"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/cloudcontrol"
+	"github.com/praetorian-inc/nebula/pkg/links/aws/cloudfront"
 	"github.com/praetorian-inc/nebula/pkg/links/aws/lambda"
 	"github.com/praetorian-inc/nebula/pkg/links/options"
 	"github.com/praetorian-inc/nebula/pkg/types"
@@ -45,40 +47,50 @@ func (a *AwsPublicResources) Initialize() error {
 	return nil
 }
 
-func (a *AwsPublicResources) Process(resource *types.EnrichedResourceDescription) error {
-	constructor, ok := a.resourceMap[resource.TypeName]
-	if !ok {
-		slog.Error("Unsupported resource type", "resource", resource)
-		return nil
-	}
+func (a *AwsPublicResources) Process(input any) error {
+	slog.Debug("AwsPublicResources.Process called", "input_type", fmt.Sprintf("%T", input), "input", input)
 
-	// Deduplication for S3 buckets - only process each bucket once
-	if resource.TypeName == "AWS::S3::Bucket" {
-		// Create unique key using account_id:bucket_name
-		bucketKey := resource.AccountId + ":" + resource.Identifier
-		
-		a.processedS3Mu.Lock()
-		if a.processedS3[bucketKey] {
-			a.processedS3Mu.Unlock()
-			slog.Debug("Skipping already processed S3 bucket", "bucket", resource.Identifier, "account", resource.AccountId)
+	switch v := input.(type) {
+	case *types.EnrichedResourceDescription:
+		// Normal resource processing
+		constructor, ok := a.resourceMap[v.TypeName]
+		if !ok {
+			slog.Error("Unsupported resource type", "resource", v)
 			return nil
 		}
-		a.processedS3[bucketKey] = true
-		a.processedS3Mu.Unlock()
-		
-		slog.Debug("Processing S3 bucket for first time", "bucket", resource.Identifier, "account", resource.AccountId)
+
+		// Deduplication for S3 buckets - only process each bucket once
+		if v.TypeName == "AWS::S3::Bucket" {
+			// Create unique key using account_id:bucket_name
+			bucketKey := v.AccountId + ":" + v.Identifier
+
+			a.processedS3Mu.Lock()
+			if a.processedS3[bucketKey] {
+				a.processedS3Mu.Unlock()
+				slog.Debug("Skipping already processed S3 bucket", "bucket", v.Identifier, "account", v.AccountId)
+				return nil
+			}
+			a.processedS3[bucketKey] = true
+			a.processedS3Mu.Unlock()
+
+			slog.Debug("Processing S3 bucket for first time", "bucket", v.Identifier, "account", v.AccountId)
+		}
+
+		slog.Debug("Dispatching resource for processing", "resource_type", v.TypeName, "resource_id", v.Identifier)
+
+		// Create pair and send to processor
+		pair := &ResourceChainPair{
+			Resource:         v,
+			ChainConstructor: constructor,
+			Args:             a.Args(),
+		}
+
+		return a.Send(pair)
+
+	default:
+		slog.Debug("Unexpected input type in AwsPublicResources", "type", fmt.Sprintf("%T", input))
+		return nil
 	}
-
-	slog.Debug("Dispatching resource for processing", "resource_type", resource.TypeName, "resource_id", resource.Identifier)
-
-	// Create pair and send to processor
-	pair := &ResourceChainPair{
-		Resource:         resource,
-		ChainConstructor: constructor,
-		Args:             a.Args(),
-	}
-
-	return a.Send(pair)
 }
 
 func (a *AwsPublicResources) SupportedResourceTypes() []model.CloudResourceType {
@@ -146,6 +158,13 @@ func (a *AwsPublicResources) ResourceMap() map[string]func() chain.Chain {
 		return chain.NewChain(
 			cloudcontrol.NewCloudControlGet(),
 			NewPropertyFilterLink(cfg.WithArg("property", "PubliclyAccessible")),
+		)
+	}
+
+	resourceMap["AWS::CloudFront::Distribution"] = func() chain.Chain {
+		return chain.NewChain(
+			cloudcontrol.NewCloudControlGet(),
+			cloudfront.NewCloudFrontMisconfigurationDetector(),
 		)
 	}
 

--- a/pkg/modules/aws/recon/cloudfront_s3_takeover.go
+++ b/pkg/modules/aws/recon/cloudfront_s3_takeover.go
@@ -1,0 +1,51 @@
+package recon
+
+import (
+	"github.com/praetorian-inc/janus-framework/pkg/chain"
+	"github.com/praetorian-inc/janus-framework/pkg/chain/cfg"
+	"github.com/praetorian-inc/nebula/internal/registry"
+	"github.com/praetorian-inc/nebula/pkg/links/aws/cloudfront"
+	"github.com/praetorian-inc/nebula/pkg/links/options"
+	"github.com/praetorian-inc/nebula/pkg/outputters"
+)
+
+func init() {
+	registry.Register("aws", "recon", AwsCloudFrontS3Takeover.Metadata().Properties()["id"].(string), *AwsCloudFrontS3Takeover)
+}
+
+var AwsCloudFrontS3Takeover = chain.NewModule(
+	cfg.NewMetadata(
+		"CloudFront S3 Origin Takeover Detection",
+		"Detects CloudFront distributions with S3 origins pointing to non-existent buckets, which could allow attackers to take over the domain by creating the missing bucket. Also identifies Route53 records pointing to vulnerable distributions.",
+	).WithProperties(map[string]any{
+		"id":          "cloudfront-s3-takeover",
+		"platform":    "aws",
+		"opsec_level": "safe",
+		"authors":     []string{"Praetorian"},
+		"references": []string{
+			"https://labs.detectify.com/writeups/hostile-subdomain-takeover-using-cloudfront/",
+			"https://www.hackerone.com/application-security/guide-subdomain-takeovers",
+			"https://github.com/EdOverflow/can-i-take-over-xyz",
+		},
+	}),
+).WithLinks(
+	cloudfront.NewCloudFrontDistributionEnumerator,
+	cloudfront.NewCloudFrontS3OriginChecker,
+	cloudfront.NewRoute53DomainFinder,
+).WithOutputters(
+	outputters.NewRiskConsoleOutputter,
+	outputters.NewRuntimeJSONOutputter,
+	outputters.NewRuntimeMarkdownOutputter,
+).WithInputParam(
+	options.AwsProfile(),
+).WithInputParam(
+	options.AwsRegions(),
+).WithInputParam(
+	cfg.NewParam[string]("filename", "Base filename for output").
+		WithDefault("cloudfront-s3-takeover").
+		WithShortcode("f"),
+).WithParams(
+	cfg.NewParam[string]("module-name", "name of the module for dynamic file naming"),
+).WithConfigs(
+	cfg.WithArg("module-name", "cloudfront-s3-takeover"),
+).WithAutoRun()


### PR DESCRIPTION
Sibling PR for testing: https://github.com/praetorian-inc/Nebula-Cloud-Infrastructures/pull/11
Jira Ticket: https://praetorianlabs.atlassian.net/browse/PS-239

This module searches for AWS CloudFront Distributions with non-existent S3 buckets that could allow an attacker to take over the CloudFront distribution. If a domain uses the CloudFront Distribution, it effectively allows the attacker to take over the domain/subdomain.